### PR TITLE
feat: Add CI workflow and update sponsorship details

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 16.x
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build site
+      run: npm run generate:local 
+      env:
+        AIRTABLEKEY: ${{ secrets.AIRTABLEKEY }}
+        BUTTERKEY: ${{ secrets.BUTTERKEY }}

--- a/components/becampSponsors.vue
+++ b/components/becampSponsors.vue
@@ -46,7 +46,7 @@
         <h2>Want to become a beCamp sponsor?</h2>
         <p>We're always in need of an extra helping hand.</p>
         <a
-          href="mailto:todd.gerdy+becamp@gmail.com?subject=beCamp/beSwarm Sponsorship&body=Hello! I'd like to learn more about becoming a sponsor for beCamp/beSwarm!"
+          href="mailto:ozanzal+becamp@gmail.com?subject=beCamp/beSwarm Sponsorship&body=Hello! I'd like to learn more about becoming a sponsor for beCamp/beSwarm!"
           name="Email beCamp/beSwarm sponsorship organizer"
         >
           <button>Become a Sponsor</button>

--- a/libs/api.js
+++ b/libs/api.js
@@ -32,7 +32,7 @@ class Api {
     // https://airtable.com/<key>/api/docs
     //
     // Use this <key> as the string argument to Airtable.base('...').
-    this.airtable = Airtable.base('appLR1JlBgJZYqKTc') // beCamp 2022
+    this.airtable = Airtable.base('applbJgB5JNe73ode') // beCamp 2024
     Vue.prototype.$api = this
   }
 

--- a/pages/attendees.vue
+++ b/pages/attendees.vue
@@ -15,7 +15,7 @@
       </div>
       <div class="tac register">
         <a
-          href="https://airtable.com/shr8pscmdKHqKEBBN"
+          href="EVENTBRITE_LINIK"
           target="_blank" rel="noopener"
         >
           <button>Register Now</button>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,7 +16,7 @@
           <div v-html="setAttendeeCount(page.homepage_hero_content)"></div>
           <!-- Wondering where this is? Go to "Guests" in the forked Airtable Base and change the "Grid view" to the form's view. -->
           <a
-            href="https://airtable.com/shr8pscmdKHqKEBBN"
+            href="EVENTBRITE_LINIK"
             target="_blank" rel="noopener"
           >
             <button>Register Now</button>
@@ -89,7 +89,7 @@
         <h2>Let us know you're attending!</h2>
         <p>It's quick and easy, and guarantees we get your shirt size correct.</p>
         <a
-          href="https://airtable.com/shr8pscmdKHqKEBBN"
+          href="EVENTBRITE_LINIK"
           target="_blank" rel="noopener"
         >
           <button>Register Now</button>

--- a/store/system.js
+++ b/store/system.js
@@ -27,10 +27,6 @@ export const state = () => ({
       name: 'History',
       route: '/history'
     },
-    {
-      name: 'Attendees',
-      route: '/attendees'
-    },
   ]
 })
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "github": {
     "silent": false,
-    "enabled": true
+    "enabled": false
   },
   "public": false
 }


### PR DESCRIPTION
- Created a GitHub Actions workflow for Node.js CI to automate builds on push and pull request events to the main branch.
- Updated sponsorship email contact in `becampSponsors.vue` to reflect the new organizer's email.
- Changed Airtable base key in `api.js` to the one for beCamp 2024.
- Replaced registration links in `attendees.vue` and `index.vue` with a placeholder for Eventbrite link.
- Removed the 'Attendees' entry from the navigation in `system.js`.

Fixes #

## Proposed Changes

  -
  -
  -
