### PR TITLE
Add file movement step to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,7 @@ jobs:
       env:
         AIRTABLEKEY: ${{ secrets.AIRTABLEKEY }}
         BUTTERKEY: ${{ secrets.BUTTERKEY }}
+    - name: Move files
+      run: |
+        mkdir -p docs
+        mv dist/* docs


### PR DESCRIPTION
- Added a step to move generated files from the `dist` directory to the `/site` directory in the GitHub Actions build workflow.

Fixes #

## Proposed Changes

  -
  -
  -
